### PR TITLE
Sort filepaths

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -42,13 +42,15 @@ func (b *siteBuilder) Build() error {
 		return fmt.Errorf("Could not copy public directory: %w", err)
 	}
 
-	err = b.createPages()
+	sortedPaths := common.SortPageMapByPath(b.PageMap)
+
+	err = b.createPages(sortedPaths)
 	if err != nil {
 		return fmt.Errorf("An error occurred while creating pages: %w", err)
 	}
 
 	if b.WithSitemap {
-		err = b.createSitemap()
+		err = b.createSitemap(sortedPaths)
 		if err != nil {
 			return fmt.Errorf("An error occurred while creating sitemap: %w", err)
 		}
@@ -57,9 +59,8 @@ func (b *siteBuilder) Build() error {
 	return nil
 }
 
-func (b *siteBuilder) createPages() error {
-	sortedPaths := common.SortPageMapByPath(b.PageMap)
-	for _, path := range sortedPaths {
+func (b *siteBuilder) createPages(paths []string) error {
+	for _, path := range paths {
 		fmt.Printf("- creating %s...\n", path)
 		f, err := file.CreateFile(b.DistDir + path)
 		if err != nil {
@@ -71,12 +72,12 @@ func (b *siteBuilder) createPages() error {
 	return nil
 }
 
-func (b *siteBuilder) createSitemap() error {
+func (b *siteBuilder) createSitemap(paths []string) error {
 	f, err := file.CreateFile(b.DistDir + "/sitemap.xml")
 	if err != nil {
 		return err
 	}
-	sitemap := common.BuildSitemap(b.SiteDomain, b.PageMap)
+	sitemap := common.BuildSitemap(b.SiteDomain, paths)
 	_, err = f.Write([]byte(sitemap))
 	return err
 }

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -58,12 +58,14 @@ func (b *siteBuilder) Build() error {
 }
 
 func (b *siteBuilder) createPages() error {
-	for path, handler := range *b.PageMap {
+	sortedPaths := common.SortPageMapByPath(b.PageMap)
+	for _, path := range sortedPaths {
 		fmt.Printf("- creating %s...\n", path)
 		f, err := file.CreateFile(b.DistDir + path)
 		if err != nil {
 			return err
 		}
+		handler := (*b.PageMap)[path]
 		handler(f)
 	}
 	return nil

--- a/internal/common/sitemap.go
+++ b/internal/common/sitemap.go
@@ -3,20 +3,34 @@ package common
 import (
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 )
 
 func BuildSitemap(domain string, pageMap *PageMap) string {
 	var builder strings.Builder
+	sortedPaths := sortByPath(pageMap)
+
 	builder.WriteString(`<?xml version="1.0" encoding="UTF-8"?>`)
 	builder.WriteString(`<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`)
-	for path := range *pageMap {
+	for _, path := range sortedPaths {
 		urlPath := fileToUrlPath(path)
 		builder.WriteString(fmt.Sprintf("<url><loc>https://%s%s</loc></url>", domain, urlPath))
 	}
 	builder.WriteString("</urlset>")
 
 	return builder.String()
+}
+
+func sortByPath(pageMap *PageMap) []string {
+	keys := make([]string, len(*pageMap))
+	i := 0
+	for k := range *pageMap {
+		keys[i] = k
+		i++
+	}
+	slices.Sort(keys)
+	return keys
 }
 
 func fileToUrlPath(path string) string {

--- a/internal/common/sitemap.go
+++ b/internal/common/sitemap.go
@@ -7,13 +7,12 @@ import (
 	"strings"
 )
 
-func BuildSitemap(domain string, pageMap *PageMap) string {
+func BuildSitemap(domain string, paths []string) string {
 	var builder strings.Builder
-	sortedPaths := SortPageMapByPath(pageMap)
 
 	builder.WriteString(`<?xml version="1.0" encoding="UTF-8"?>`)
 	builder.WriteString(`<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`)
-	for _, path := range sortedPaths {
+	for _, path := range paths {
 		urlPath := fileToUrlPath(path)
 		builder.WriteString(fmt.Sprintf("<url><loc>https://%s%s</loc></url>", domain, urlPath))
 	}

--- a/internal/common/sitemap.go
+++ b/internal/common/sitemap.go
@@ -9,7 +9,7 @@ import (
 
 func BuildSitemap(domain string, pageMap *PageMap) string {
 	var builder strings.Builder
-	sortedPaths := sortByPath(pageMap)
+	sortedPaths := SortPageMapByPath(pageMap)
 
 	builder.WriteString(`<?xml version="1.0" encoding="UTF-8"?>`)
 	builder.WriteString(`<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`)
@@ -22,7 +22,7 @@ func BuildSitemap(domain string, pageMap *PageMap) string {
 	return builder.String()
 }
 
-func sortByPath(pageMap *PageMap) []string {
+func SortPageMapByPath(pageMap *PageMap) []string {
 	keys := make([]string, len(*pageMap))
 	i := 0
 	for k := range *pageMap {

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -37,11 +37,13 @@ func (s *siteServer) SetupRoutes() http.Handler {
 	mux := http.NewServeMux()
 	var rootHandler http.HandlerFunc
 
-	for path, handler := range *s.PageMap {
+	sortedPaths := common.SortPageMapByPath(s.PageMap)
+	for _, path := range sortedPaths {
 		fmt.Println("- serving page: ", path)
 
+		pageHandler := (*s.PageMap)[path]
 		handler := func(w http.ResponseWriter, r *http.Request) {
-			handler(w)
+			pageHandler(w)
 		}
 
 		pathWithoutExt := strings.TrimSuffix(path, filepath.Ext(path))

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -56,7 +56,7 @@ func (s *siteServer) SetupRoutes() http.Handler {
 	}
 
 	if s.WithSitemap {
-		sitemap := common.BuildSitemap(s.SiteDomain, s.PageMap)
+		sitemap := common.BuildSitemap(s.SiteDomain, sortedPaths)
 		mux.HandleFunc("/sitemap.xml", func(w http.ResponseWriter, r *http.Request) {
 			w.Write([]byte(sitemap))
 		})


### PR DESCRIPTION
To ensure a sorted output when building and serving pages. Also guarantees consistent output when generating `sitemap.xml`