### PR TITLE
Preserving insertion order of pages

### DIFF
--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -17,17 +17,31 @@ func TestSiteBuilder(t *testing.T) {
 		"index":    "<h1>Index Page</h1>",
 		"foo":      "<h1>Foo Page</h1>",
 		"testfile": "Hello from text file",
-		"sitemap":  `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>https://test.com/</loc></url><url><loc>https://test.com/nested/foo</loc></url></urlset>`,
+		"sitemap":  `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>https://test.com/</loc></url><url><loc>https://test.com/nested/foo</loc></url><url><loc>https://test.com/zzz</loc></url><url><loc>https://test.com/aaa</loc></url></urlset>`,
 	}
 
-	testPages := &common.PageMap{
-		"/index.html": func(w io.Writer) {
-			t := template.Must(template.New("").Parse(body["index"]))
-			t.Execute(w, nil)
+	testPages := &[]common.Page{
+		{
+			Path: "/index.html",
+			Handler: func(w io.Writer) {
+				t := template.Must(template.New("").Parse(body["index"]))
+				t.Execute(w, nil)
+			},
 		},
-		"/nested/foo.htm": func(w io.Writer) {
-			t := template.Must(template.New("").Parse(body["foo"]))
-			t.Execute(w, nil)
+		{
+			Path: "/nested/foo.htm",
+			Handler: func(w io.Writer) {
+				t := template.Must(template.New("").Parse(body["foo"]))
+				t.Execute(w, nil)
+			},
+		},
+		{
+			Path:    "/zzz.html",
+			Handler: func(w io.Writer) {},
+		},
+		{
+			Path:    "/aaa.html",
+			Handler: func(w io.Writer) {},
 		},
 	}
 

--- a/internal/common/sitemap.go
+++ b/internal/common/sitemap.go
@@ -7,13 +7,13 @@ import (
 	"strings"
 )
 
-func BuildSitemap(domain string, paths []string) string {
+func BuildSitemap(domain string, pages *[]Page) string {
 	var builder strings.Builder
 
 	builder.WriteString(`<?xml version="1.0" encoding="UTF-8"?>`)
 	builder.WriteString(`<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`)
-	for _, path := range paths {
-		urlPath := fileToUrlPath(path)
+	for _, p := range *pages {
+		urlPath := fileToUrlPath(p.Path)
 		builder.WriteString(fmt.Sprintf("<url><loc>https://%s%s</loc></url>", domain, urlPath))
 	}
 	builder.WriteString("</urlset>")

--- a/internal/common/types.go
+++ b/internal/common/types.go
@@ -3,3 +3,8 @@ package common
 import "io"
 
 type PageMap map[string]func(w io.Writer)
+
+type Page struct {
+	Path    string
+	Handler func(w io.Writer)
+}

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -22,14 +22,20 @@ func TestSiteServer(t *testing.T) {
 		"sitemap":  `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>https://test.com/</loc></url><url><loc>https://test.com/nested/foo</loc></url></urlset>`,
 	}
 
-	testPages := &common.PageMap{
-		"/index.html": func(w io.Writer) {
-			t := template.Must(template.New("").Parse(body["index"]))
-			t.Execute(w, nil)
+	testPages := &[]common.Page{
+		{
+			Path: "/index.html",
+			Handler: func(w io.Writer) {
+				t := template.Must(template.New("").Parse(body["index"]))
+				t.Execute(w, nil)
+			},
 		},
-		"/nested/foo.htm": func(w io.Writer) {
-			t := template.Must(template.New("").Parse(body["foo"]))
-			t.Execute(w, nil)
+		{
+			Path: "/nested/foo.htm",
+			Handler: func(w io.Writer) {
+				t := template.Must(template.New("").Parse(body["foo"]))
+				t.Execute(w, nil)
+			},
 		},
 	}
 


### PR DESCRIPTION
It felt a little strange ordering sitemap and build/serving logs alphabetically by file path.

I wanted to keep the order of insertion by the user. For this, I moved back to a slice of pages, rather than a map. 

However when adding a new page, I'm keeping a map of file paths to lookup if a page already exists to keep o(1) lookup time. If there were a native ordered map in Go, I would have opted to use this, but I feel this approach is an ok compromise in terms of memory and complexity.