### PR TITLE
[FEAT] Add base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Optionally you can pass configuration options when creating the instance:
 ```go
 lp, err := litepage.New("hello-world.com",
     litepage.WithDistDir("custom_dist"),
+    litepage.WithBasePath("/custom-base")
     litepage.WithPublicDir("custom_public"),
     litepage.WithoutSitemap(),
 )
@@ -101,6 +102,7 @@ lp, err := litepage.New("hello-world.com",
 #### Options
 
 - `WithDistDir` - Specify a custom dist directory to be used, that is created/written to when building the static site. Default value is `dist`.
+- `WithBasePath` - Specify the base path of your site, if it is not the root of the domain (for example, if deploying to GitHub Pages). If set, all static assets and links should add the base as a prefix.
 - `WithPublicDir` - Specify a custom public directory to be used, that is read to retrieve static assets when building or serving the static site. Default value is `public`.
 - `WithoutSitemap` - Do not create a sitemap of your site. By default a `sitemap.xml` is created mapping all pages of the static site. Disable this if you do not want this, or if you want to create your own sitemap.
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Optionally you can pass configuration options when creating the instance:
 ```go
 lp, err := litepage.New("hello-world.com",
     litepage.WithDistDir("custom_dist"),
-    litepage.WithBasePath("/custom-base")
+    litepage.WithBasePath("/custom-base"),
     litepage.WithPublicDir("custom_public"),
     litepage.WithoutSitemap(),
 )
@@ -102,7 +102,7 @@ lp, err := litepage.New("hello-world.com",
 #### Options
 
 - `WithDistDir` - Specify a custom dist directory to be used, that is created/written to when building the static site. Default value is `dist`.
-- `WithBasePath` - Specify the base path of your site, if it is not the root of the domain (for example, if deploying to GitHub Pages). If set, all static assets and links should add the base as a prefix.
+- `WithBasePath` - Specify the base path of your site, if it is not the root of the domain (for example, if deploying to GitHub Pages). If set, all static assets and links should add the base as a prefix. The path should always start with a `/` and not end with a trailing slash (otherwise an error will be returned).
 - `WithPublicDir` - Specify a custom public directory to be used, that is read to retrieve static assets when building or serving the static site. Default value is `public`.
 - `WithoutSitemap` - Do not create a sitemap of your site. By default a `sitemap.xml` is created mapping all pages of the static site. Disable this if you do not want this, or if you want to create your own sitemap.
 

--- a/example/main.go
+++ b/example/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 func main() {
-	lp, err := litepage.New("example.dev")
+	lp, err := litepage.New("example.dev", litepage.WithBasePath("/litepage"))
 	if err != nil {
 		log.Fatalf("Could not create app: %v", err)
 	}

--- a/example/view/base.html
+++ b/example/view/base.html
@@ -4,8 +4,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="icon" type="image/svg+xml" href="/litepage.svg" />
-    <link href="/styles.css?v={{ version }}" rel="stylesheet" />
+    <link rel="icon" type="image/svg+xml" href="/litepage/litepage.svg" />
+    <link href="/litepage/styles.css?v={{ version }}" rel="stylesheet" />
     <title>{{ template "title" . }}</title>
     {{ template "scripts" }}
   </head>

--- a/example/view/home.html
+++ b/example/view/home.html
@@ -1,18 +1,17 @@
-{{ define "title" }}{{ .Title }}{{ end }} {{define "scripts"}}{{end}} {{ define
-"body" }}
-<!-- <img -->
-<!--   height="70" -->
-<!--   width="412" -->
-<!--   class="logo" -->
-<!--   src="/litepage-text.svg" -->
-<!--   alt="{{ .Header }}" -->
-<!-- /> -->
+<!-- title -->
+{{ define "title" }}{{ .Title }}{{ end }}
+
+<!-- scripts -->
+{{define "scripts"}}{{end}}
+
+<!-- body -->
+{{ define "body" }}
 <div class="box">
   <img
     height="140"
     width="140"
     class="logo"
-    src="/litepage.svg"
+    src="/litepage/litepage.svg"
     alt="Litepage logo"
   />
   <h1>{{ .Header }}</h1>

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -18,6 +18,7 @@ type Config struct {
 	PublicDir   string
 	Pages       *[]model.Page
 	SiteDomain  string
+	BasePath    string
 	WithSitemap bool
 }
 
@@ -80,7 +81,7 @@ func (b *siteBuilder) createSitemap() error {
 	if err != nil {
 		return err
 	}
-	smap := sitemap.BuildSitemap(b.Config.SiteDomain, b.Config.Pages)
+	smap := sitemap.Build(b.Config.SiteDomain, b.Config.BasePath, b.Config.Pages)
 	_, err = f.Write([]byte(smap))
 	return err
 }

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/man-on-box/litepage/internal/common"
 	"github.com/man-on-box/litepage/internal/file"
+	"github.com/man-on-box/litepage/internal/model"
+	"github.com/man-on-box/litepage/internal/sitemap"
 )
 
 type SiteBuilder interface {
@@ -15,7 +16,7 @@ type SiteBuilder interface {
 type Config struct {
 	DistDir     string
 	PublicDir   string
-	Pages       *[]common.Page
+	Pages       *[]model.Page
 	SiteDomain  string
 	WithSitemap bool
 }
@@ -79,7 +80,7 @@ func (b *siteBuilder) createSitemap() error {
 	if err != nil {
 		return err
 	}
-	sitemap := common.BuildSitemap(b.Config.SiteDomain, b.Config.Pages)
-	_, err = f.Write([]byte(sitemap))
+	smap := sitemap.BuildSitemap(b.Config.SiteDomain, b.Config.Pages)
+	_, err = f.Write([]byte(smap))
 	return err
 }

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -12,7 +12,7 @@ type SiteBuilder interface {
 	Build() error
 }
 
-type siteBuilder struct {
+type Config struct {
 	DistDir     string
 	PublicDir   string
 	Pages       *[]common.Page
@@ -20,22 +20,22 @@ type siteBuilder struct {
 	WithSitemap bool
 }
 
-func New(distDir string, publicDir string, pages *[]common.Page, siteDomain string, withSitemap bool) SiteBuilder {
+type siteBuilder struct {
+	Config Config
+}
+
+func New(config Config) SiteBuilder {
 	b := &siteBuilder{
-		DistDir:     distDir,
-		PublicDir:   publicDir,
-		Pages:       pages,
-		SiteDomain:  siteDomain,
-		WithSitemap: withSitemap,
+		Config: config,
 	}
 	return b
 }
 
 func (b *siteBuilder) Build() error {
-	fmt.Printf("LITEPAGE building site '%s'...\n", b.SiteDomain)
+	fmt.Printf("LITEPAGE building site '%s'...\n", b.Config.SiteDomain)
 	startTime := time.Now()
 
-	err := file.CopyDir(b.PublicDir, b.DistDir)
+	err := file.CopyDir(b.Config.PublicDir, b.Config.DistDir)
 	if err != nil {
 		return fmt.Errorf("Could not copy public directory: %w", err)
 	}
@@ -45,27 +45,27 @@ func (b *siteBuilder) Build() error {
 		return fmt.Errorf("An error occurred while creating pages: %w", err)
 	}
 
-	if b.WithSitemap {
+	if b.Config.WithSitemap {
 		err = b.createSitemap()
 		if err != nil {
 			return fmt.Errorf("An error occurred while creating sitemap: %w", err)
 		}
 	}
 
-	noOfPages := len(*b.Pages)
+	noOfPages := len(*b.Config.Pages)
 	pageStr := "page"
 	if noOfPages > 1 {
 		pageStr += "s"
 	}
 
-	fmt.Printf("Built %d %s in %.0f seconds\n", len(*b.Pages), pageStr, time.Since(startTime).Seconds())
+	fmt.Printf("Built %d %s in %.0f seconds\n", len(*b.Config.Pages), pageStr, time.Since(startTime).Seconds())
 	return nil
 }
 
 func (b *siteBuilder) createPages() error {
-	for _, p := range *b.Pages {
+	for _, p := range *b.Config.Pages {
 		fmt.Printf("- creating %s...\n", p.Path)
-		f, err := file.CreateFile(b.DistDir + p.Path)
+		f, err := file.CreateFile(b.Config.DistDir + p.Path)
 		if err != nil {
 			return err
 		}
@@ -75,11 +75,11 @@ func (b *siteBuilder) createPages() error {
 }
 
 func (b *siteBuilder) createSitemap() error {
-	f, err := file.CreateFile(b.DistDir + "/sitemap.xml")
+	f, err := file.CreateFile(b.Config.DistDir + "/sitemap.xml")
 	if err != nil {
 		return err
 	}
-	sitemap := common.BuildSitemap(b.SiteDomain, b.Pages)
+	sitemap := common.BuildSitemap(b.Config.SiteDomain, b.Config.Pages)
 	_, err = f.Write([]byte(sitemap))
 	return err
 }

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -18,7 +18,6 @@ func TestSiteBuilder(t *testing.T) {
 		"foo":            "<h1>Foo Page</h1>",
 		"text-file-body": "example text response",
 		"testfile":       "Hello from text file",
-		"sitemap":        `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>https://test.com/</loc></url><url><loc>https://test.com/nested/foo</loc></url><url><loc>https://test.com/zzz</loc></url><url><loc>https://test.com/aaa</loc></url></urlset>`,
 	}
 
 	testPages := &[]model.Page{
@@ -96,8 +95,7 @@ func TestSiteBuilder(t *testing.T) {
 			expectedContent: body["testfile"],
 		},
 		{
-			path:            "/sitemap.xml",
-			expectedContent: body["sitemap"],
+			path: "/sitemap.xml",
 		},
 	}
 
@@ -106,7 +104,9 @@ func TestSiteBuilder(t *testing.T) {
 			content, err := os.ReadFile(tmpDistDir + tt.path)
 			assert.NoError(t, err)
 
-			assert.Equal(t, tt.expectedContent, string(content))
+			if len(tt.expectedContent) > 0 {
+				assert.Equal(t, tt.expectedContent, string(content))
+			}
 		})
 	}
 }

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -64,7 +64,14 @@ func TestSiteBuilder(t *testing.T) {
 	err = os.WriteFile(testFilePath, []byte(body["testfile"]), 0644)
 	assert.NoError(t, err)
 
-	b := build.New(tmpDistDir, tmpPublicDir, testPages, "test.com", true)
+	c := build.Config{
+		DistDir:     tmpDistDir,
+		PublicDir:   tmpPublicDir,
+		Pages:       testPages,
+		SiteDomain:  "test.com",
+		WithSitemap: true,
+	}
+	b := build.New(c)
 	err = b.Build()
 	assert.NoError(t, err)
 

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/man-on-box/litepage/internal/build"
-	"github.com/man-on-box/litepage/internal/common"
+	"github.com/man-on-box/litepage/internal/model"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,7 +21,7 @@ func TestSiteBuilder(t *testing.T) {
 		"sitemap":        `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>https://test.com/</loc></url><url><loc>https://test.com/nested/foo</loc></url><url><loc>https://test.com/zzz</loc></url><url><loc>https://test.com/aaa</loc></url></urlset>`,
 	}
 
-	testPages := &[]common.Page{
+	testPages := &[]model.Page{
 		{
 			Path: "/index.html",
 			Handler: func(w io.Writer) {

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -1,4 +1,4 @@
-package common
+package model
 
 import "io"
 

--- a/internal/serve/404.html
+++ b/internal/serve/404.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>404 - Not Found</title>
+    <title>404: Not Found</title>
     <style>
       :root {
         --gray-10: hsl(258, 7%, 10%);
@@ -41,8 +41,8 @@
       }
 
       .litepage-icon {
-        width: 120px;
-        height: 120px;
+        width: 100px;
+        height: 100px;
       }
 
       pre,
@@ -52,6 +52,10 @@
         border: 1px solid var(--gray-70);
         border-radius: 3px;
         font-size: 1.3em;
+        max-width: 90vw;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
       }
 
       .center {
@@ -146,20 +150,20 @@
           />
         </g>
       </svg>
-      <h1><span class="text-accent">404</span> Not Found</h1>
-      <pre>Path: {{ .UrlPath }}</pre>
+      <h1><span class="text-accent">404:</span> Not Found</h1>
+      <pre title="{{ .UrlPath }}">Path: {{ .UrlPath }}</pre>
       <p>
         Make sure you setup a page at this path, or that the file exists in your
         <strong>public</strong> directory.
       </p>
       {{if and .BasePath .ShowBasePathError}}
       <p>
-        You have a <strong>base path</strong> configured, you might be looking
-        for:
+        <i>Psssst!</i> You have a <strong>base path</strong> configured, you
+        might be looking for:
       </p>
       <p>
         <a class="text-accent" href="{{.BasePath}}{{.UrlPath}}"
-          >{{.BasePath}}{{.UrlPath}}</a
+          ><strong>{{.BasePath}}{{.UrlPath}}</strong></a
         >
       </p>
       {{end}}

--- a/internal/serve/404.html
+++ b/internal/serve/404.html
@@ -56,6 +56,7 @@
         overflow: hidden;
         white-space: nowrap;
         text-overflow: ellipsis;
+        min-height: 2.2rem;
       }
 
       .center {

--- a/internal/serve/404.html
+++ b/internal/serve/404.html
@@ -1,0 +1,168 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>404 - Not Found</title>
+    <style>
+      :root {
+        --gray-10: hsl(258, 7%, 10%);
+        --gray-20: hsl(258, 7%, 20%);
+        --gray-30: hsl(258, 7%, 30%);
+        --gray-40: hsl(258, 7%, 40%);
+        --gray-50: hsl(258, 7%, 50%);
+        --gray-60: hsl(258, 7%, 60%);
+        --gray-70: hsl(258, 7%, 70%);
+        --gray-80: hsl(258, 7%, 80%);
+        --gray-90: hsl(258, 7%, 90%);
+        --black: #0f0f0f;
+        --accent: #ff66a9;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      html {
+        background: var(--black);
+        color-scheme: dark;
+        accent-color: var(--accent);
+      }
+
+      body {
+        color: var(--gray-90);
+        font-family:
+          ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+          "Liberation Mono", "Courier New", monospace;
+        margin: 0;
+      }
+
+      .text-accent {
+        color: var(--accent);
+      }
+
+      .litepage-icon {
+        width: 120px;
+        height: 120px;
+      }
+
+      pre,
+      code {
+        padding: 8px;
+        background: var(--gray-20);
+        border: 1px solid var(--gray-70);
+        border-radius: 3px;
+        font-size: 1.3em;
+      }
+
+      .center {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        height: 100vh;
+        width: 100vw;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="center">
+      <svg
+        class="litepage-icon"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 500 500"
+      >
+        <defs>
+          <filter
+            id="b"
+            color-interpolation-filters="sRGB"
+            x="-50%"
+            y="-50%"
+            width="200%"
+            height="200%"
+          >
+            <feGaussianBlur in="SourceAlpha" stdDeviation="4" />
+            <feOffset />
+            <feComponentTransfer result="offsetblur">
+              <feFuncA type="linear" slope="1.3" />
+            </feComponentTransfer>
+            <feFlood flood-color="#ff66a9" />
+            <feComposite in2="offsetblur" operator="in" />
+            <feMerge>
+              <feMergeNode />
+              <feMergeNode in="SourceGraphic" />
+            </feMerge>
+          </filter>
+          <filter
+            id="c"
+            color-interpolation-filters="sRGB"
+            x="-50%"
+            y="-50%"
+            width="200%"
+            height="200%"
+          >
+            <feGaussianBlur in="SourceAlpha" stdDeviation="5" />
+            <feOffset />
+            <feComponentTransfer result="offsetblur">
+              <feFuncA type="linear" slope="1.3" />
+            </feComponentTransfer>
+            <feFlood flood-color="#fdd700" />
+            <feComposite in2="offsetblur" operator="in" />
+            <feMerge>
+              <feMergeNode />
+              <feMergeNode in="SourceGraphic" />
+            </feMerge>
+          </filter>
+          <linearGradient
+            gradientUnits="userSpaceOnUse"
+            x1="535.209"
+            y1="91.777"
+            x2="535.209"
+            y2="292.234"
+            id="a"
+            gradientTransform="matrix(1.2425 2.17753 -3.88523 2.12522 859.915 -995.336)"
+          >
+            <stop offset="0" stop-color="rgb(47.451% 100% 96.863%)" />
+            <stop offset="1" stop-color="rgb(0% 59.265% 57.001%)" />
+          </linearGradient>
+        </defs>
+        <g paint-order="fill">
+          <path
+            d="M739.607 162.49q32.019-62.699 64.037 0l207.308 405.952q32.019 62.699-32.019 62.699H564.318q-64.038 0-32.019-62.699Z"
+            filter="none"
+            fill="url(#a)"
+            transform="translate(-521.625 -131.14)"
+          />
+          <path
+            d="m846.91 247.215 46.503 91.062-314.037 137.979 38.688-75.759L846.91 247.215Z"
+            fill="#ff66a9"
+            filter="url(#b)"
+            transform="translate(-521.625 -131.14)"
+          />
+          <path
+            d="m892.349 336.193 48.546 95.064-395.844 112.215 35.075-68.685 312.223-138.594Z"
+            fill="#fdd600"
+            filter="url(#c)"
+            transform="translate(-521.625 -131.14)"
+          />
+        </g>
+      </svg>
+      <h1><span class="text-accent">404</span> Not Found</h1>
+      <pre>Path: {{ .UrlPath }}</pre>
+      <p>
+        Make sure you setup a page at this path, or that the file exists in your
+        <strong>public</strong> directory.
+      </p>
+      {{if and .BasePath .ShowBasePathError}}
+      <p>
+        You have a <strong>base path</strong> configured, you might be looking
+        for:
+      </p>
+      <p>
+        <a class="text-accent" href="{{.BasePath}}{{.UrlPath}}"
+          >{{.BasePath}}{{.UrlPath}}</a
+        >
+      </p>
+      {{end}}
+    </main>
+  </body>
+</html>

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -94,7 +94,7 @@ func (s *siteServer) SetupRoutes() http.Handler {
 	}
 
 	if s.Config.WithSitemap {
-		smap := sitemap.BuildSitemap(s.Config.SiteDomain, s.Config.Pages)
+		smap := sitemap.Build(s.Config.SiteDomain, s.Config.BasePath, s.Config.Pages)
 		mux.HandleFunc(s.Config.BasePath+"/sitemap.xml", func(w http.ResponseWriter, r *http.Request) {
 			w.Write([]byte(smap))
 		})

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -1,9 +1,13 @@
 package serve
 
 import (
+	_ "embed"
 	"fmt"
+	"html/template"
 	"io"
+	"log"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -11,6 +15,11 @@ import (
 )
 
 const defaultPort = "3000"
+
+//go:embed 404.html
+var notFoundHTML string
+
+var notFoundTmpl = template.Must(template.New("404").Parse(notFoundHTML))
 
 type SiteServer interface {
 	Serve(port string) error
@@ -21,6 +30,7 @@ type Config struct {
 	PublicDir   string
 	Pages       *[]common.Page
 	SiteDomain  string
+	BasePath    string
 	WithSitemap bool
 }
 
@@ -38,24 +48,28 @@ func New(config Config) SiteServer {
 func (s *siteServer) SetupRoutes() http.Handler {
 	mux := http.NewServeMux()
 	var rootHandler func(w io.Writer)
-	registeredPaths := map[string]any{}
+	registeredPaths := map[string]bool{}
 
 	registerHandler := func(path string, handler func(w io.Writer)) {
-		registeredPaths[path] = struct{}{}
+		registeredPaths[path] = true
 
 		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
-			_, exists := registeredPaths[r.URL.Path]
-			if exists {
+			if registeredPaths[r.URL.Path] {
 				handler(w)
 			} else {
-				http.NotFound(w, r)
+				s.customNotFound(w, r)
 			}
 		})
 	}
 
 	for _, p := range *s.Config.Pages {
-		fmt.Println("- serving page: ", p.Path)
-		registerHandler(p.Path, p.Handler)
+		fullPath := s.Config.BasePath + p.Path
+		pageHandler := func(w io.Writer) {
+			log.Printf("[%d]: %s", http.StatusOK, fullPath)
+			p.Handler(w)
+
+		}
+		registerHandler(fullPath, pageHandler)
 
 		fileExt := filepath.Ext(p.Path)
 		isNotHTML := fileExt != ".html" && fileExt != ".htm"
@@ -64,33 +78,37 @@ func (s *siteServer) SetupRoutes() http.Handler {
 			continue
 		}
 
-		pathWithoutExt := strings.TrimSuffix(p.Path, fileExt)
-		registerHandler(pathWithoutExt, p.Handler)
+		pathWithoutExt := strings.TrimSuffix(fullPath, fileExt)
+		registerHandler(pathWithoutExt, pageHandler)
 
 		if strings.HasSuffix(pathWithoutExt, "/index") {
-			if pathWithoutExt == "/index" {
-				rootHandler = p.Handler
+			if pathWithoutExt == s.Config.BasePath+"/index" {
+				rootHandler = pageHandler
 			} else {
-				path := strings.TrimSuffix(pathWithoutExt, "/index")
-				registerHandler(path, p.Handler)
-				registerHandler(path+"/", p.Handler)
+				trimmedPath := strings.TrimSuffix(pathWithoutExt, "/index")
+				registerHandler(trimmedPath, pageHandler)
+				registerHandler(trimmedPath+"/", pageHandler)
 			}
 		}
 	}
 
 	if s.Config.WithSitemap {
 		sitemap := common.BuildSitemap(s.Config.SiteDomain, s.Config.Pages)
-		mux.HandleFunc("/sitemap.xml", func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc(s.Config.BasePath+"/sitemap.xml", func(w http.ResponseWriter, r *http.Request) {
 			w.Write([]byte(sitemap))
 		})
 	}
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/" && rootHandler != nil {
+		if r.URL.Path == s.Config.BasePath+"/" && rootHandler != nil {
 			rootHandler(w)
-		} else {
-			http.ServeFile(w, r, s.Config.PublicDir+r.URL.Path)
+			return
 		}
+		if len(s.Config.BasePath) > 0 && !strings.HasPrefix(r.URL.Path, s.Config.BasePath) {
+			s.customNotFound(w, r)
+			return
+		}
+		s.serveFile(w, r)
 	})
 	return mux
 }
@@ -104,4 +122,26 @@ func (s *siteServer) Serve(port string) error {
 
 	mux := s.SetupRoutes()
 	return http.ListenAndServe("localhost:"+usePort, mux)
+}
+
+func (s *siteServer) serveFile(w http.ResponseWriter, r *http.Request) {
+	staticPath := strings.TrimPrefix(r.URL.Path, s.Config.BasePath)
+	requestedFile := filepath.Join(s.Config.PublicDir, filepath.Clean(staticPath))
+	if _, err := os.Stat(requestedFile); os.IsNotExist(err) {
+		s.customNotFound(w, r)
+	} else {
+		http.ServeFile(w, r, s.Config.PublicDir+staticPath)
+	}
+}
+
+func (s *siteServer) customNotFound(w http.ResponseWriter, r *http.Request) {
+	log.Printf("[%d]: %s", http.StatusNotFound, r.URL.Path)
+	w.WriteHeader(http.StatusNotFound)
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	showBasePathError := len(s.Config.BasePath) > 0 && !strings.HasPrefix(r.URL.Path, s.Config.BasePath)
+	notFoundTmpl.Execute(w, struct {
+		ShowBasePathError bool
+		BasePath          string
+		UrlPath           string
+	}{ShowBasePathError: showBasePathError, BasePath: s.Config.BasePath, UrlPath: r.URL.Path})
 }

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -11,7 +11,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/man-on-box/litepage/internal/common"
+	"github.com/man-on-box/litepage/internal/model"
+	"github.com/man-on-box/litepage/internal/sitemap"
 )
 
 const defaultPort = "3000"
@@ -28,7 +29,7 @@ type SiteServer interface {
 
 type Config struct {
 	PublicDir   string
-	Pages       *[]common.Page
+	Pages       *[]model.Page
 	SiteDomain  string
 	BasePath    string
 	WithSitemap bool
@@ -93,9 +94,9 @@ func (s *siteServer) SetupRoutes() http.Handler {
 	}
 
 	if s.Config.WithSitemap {
-		sitemap := common.BuildSitemap(s.Config.SiteDomain, s.Config.Pages)
+		smap := sitemap.BuildSitemap(s.Config.SiteDomain, s.Config.Pages)
 		mux.HandleFunc(s.Config.BasePath+"/sitemap.xml", func(w http.ResponseWriter, r *http.Request) {
-			w.Write([]byte(sitemap))
+			w.Write([]byte(smap))
 		})
 	}
 

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -19,7 +19,6 @@ const defaultPort = "3000"
 
 //go:embed 404.html
 var notFoundHTML string
-
 var notFoundTmpl = template.Must(template.New("404").Parse(notFoundHTML))
 
 type SiteServer interface {

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -24,7 +24,6 @@ func TestSiteServer(t *testing.T) {
 		"nested-nested-bar":   "<h1>Nested nested Bar Page</h1>",
 		"text-file-body":      "example text response",
 		"testfile":            "Hello from static text file",
-		"sitemap":             `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>https://test.com/</loc></url><url><loc>https://test.com/foo</loc></url><url><loc>https://test.com/nested/</loc></url><url><loc>https://test.com/nested/foo</loc></url><url><loc>https://test.com/nested/nested/</loc></url><url><loc>https://test.com/nested/nested/bar</loc></url></urlset>`,
 	}
 
 	testPages := &[]model.Page{
@@ -218,10 +217,9 @@ func TestSiteServer(t *testing.T) {
 			expectedBody:   body["testfile"],
 		},
 		{
-			name:           "Returns expected sitemap",
+			name:           "Sitemap exists",
 			path:           "/sitemap.xml",
 			expectedStatus: http.StatusOK,
-			expectedBody:   body["sitemap"],
 		},
 	}
 

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -248,4 +248,31 @@ func TestSiteServer(t *testing.T) {
 			}
 		})
 	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+" with base path", func(t *testing.T) {
+			c := serve.Config{
+				PublicDir:   tmpPublicDir,
+				Pages:       testPages,
+				SiteDomain:  "test.com",
+				BasePath:    "/test",
+				WithSitemap: true,
+			}
+			s := serve.New(c)
+			routes := s.SetupRoutes()
+			server := httptest.NewServer(routes)
+			defer server.Close()
+
+			resp, err := http.Get(server.URL + c.BasePath + tt.path)
+			assert.NoError(t, err)
+			defer resp.Body.Close()
+
+			body, err := io.ReadAll(resp.Body)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedStatus, resp.StatusCode)
+			if len(tt.expectedBody) > 0 {
+				assert.Equal(t, tt.expectedBody, string(body))
+			}
+		})
+	}
 }

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -230,7 +230,13 @@ func TestSiteServer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := serve.New(tmpPublicDir, testPages, "test.com", true)
+			c := serve.Config{
+				PublicDir:   tmpPublicDir,
+				Pages:       testPages,
+				SiteDomain:  "test.com",
+				WithSitemap: true,
+			}
+			s := serve.New(c)
 			routes := s.SetupRoutes()
 			server := httptest.NewServer(routes)
 			defer server.Close()

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -194,13 +194,11 @@ func TestSiteServer(t *testing.T) {
 			name:           "Returns 404 for non existent page",
 			path:           "/nope",
 			expectedStatus: http.StatusNotFound,
-			expectedBody:   "404 page not found\n",
 		},
 		{
 			name:           "Returns 404 for non existent nested page",
 			path:           "/nested/nope",
 			expectedStatus: http.StatusNotFound,
-			expectedBody:   "404 page not found\n",
 		},
 		{
 			name:           "Returns text body from .txt file",
@@ -212,7 +210,6 @@ func TestSiteServer(t *testing.T) {
 			name:           "Does not load text file without .txt extension",
 			path:           "/textfile-endpoint",
 			expectedStatus: http.StatusNotFound,
-			expectedBody:   "404 page not found\n",
 		},
 		{
 			name:           "Returns test file from public dir",
@@ -248,7 +245,9 @@ func TestSiteServer(t *testing.T) {
 			body, err := io.ReadAll(resp.Body)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedStatus, resp.StatusCode)
-			assert.Equal(t, tt.expectedBody, string(body))
+			if len(tt.expectedBody) > 0 {
+				assert.Equal(t, tt.expectedBody, string(body))
+			}
 		})
 	}
 }

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/man-on-box/litepage/internal/common"
+	"github.com/man-on-box/litepage/internal/model"
 	"github.com/man-on-box/litepage/internal/serve"
 	"github.com/stretchr/testify/assert"
 )
@@ -27,7 +27,7 @@ func TestSiteServer(t *testing.T) {
 		"sitemap":             `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>https://test.com/</loc></url><url><loc>https://test.com/foo</loc></url><url><loc>https://test.com/nested/</loc></url><url><loc>https://test.com/nested/foo</loc></url><url><loc>https://test.com/nested/nested/</loc></url><url><loc>https://test.com/nested/nested/bar</loc></url></urlset>`,
 	}
 
-	testPages := &[]common.Page{
+	testPages := &[]model.Page{
 		{
 			Path: "/index.html",
 			Handler: func(w io.Writer) {

--- a/internal/sitemap/sitemap.go
+++ b/internal/sitemap/sitemap.go
@@ -8,13 +8,13 @@ import (
 	"github.com/man-on-box/litepage/internal/model"
 )
 
-func BuildSitemap(domain string, pages *[]model.Page) string {
+func Build(domain string, basePath string, pages *[]model.Page) string {
 	var builder strings.Builder
 
 	builder.WriteString(`<?xml version="1.0" encoding="UTF-8"?>`)
 	builder.WriteString(`<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`)
 	for _, p := range *pages {
-		path := p.Path
+		path := basePath + p.Path
 		fileExt := filepath.Ext(path)
 		isNotHTML := fileExt != ".html" && fileExt != ".htm"
 		if isNotHTML {

--- a/internal/sitemap/sitemap.go
+++ b/internal/sitemap/sitemap.go
@@ -1,12 +1,14 @@
-package common
+package sitemap
 
 import (
 	"fmt"
 	"path/filepath"
 	"strings"
+
+	"github.com/man-on-box/litepage/internal/model"
 )
 
-func BuildSitemap(domain string, pages *[]Page) string {
+func BuildSitemap(domain string, pages *[]model.Page) string {
 	var builder strings.Builder
 
 	builder.WriteString(`<?xml version="1.0" encoding="UTF-8"?>`)

--- a/internal/sitemap/sitemap_test.go
+++ b/internal/sitemap/sitemap_test.go
@@ -1,0 +1,51 @@
+package sitemap_test
+
+import (
+	"testing"
+
+	"github.com/man-on-box/litepage/internal/model"
+	"github.com/man-on-box/litepage/internal/sitemap"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSiteMap(t *testing.T) {
+	testPages := &[]model.Page{
+		{
+			Path: "/index.html",
+		},
+		{
+			Path: "/foo.htm",
+		},
+		{
+			Path: "/nested/index.htm",
+		},
+		{
+			Path: "/nested/foo.htm",
+		},
+		{
+			Path: "/nested/nested/index.html",
+		},
+		{
+			Path: "/nested/nested/bar.html",
+		},
+		{
+			Path: "/a-text-file.txt",
+		},
+	}
+
+	t.Run("creates expected sitemap from pages", func(t *testing.T) {
+		smap := sitemap.Build("test.com", "", testPages)
+
+		expected := `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>https://test.com/</loc></url><url><loc>https://test.com/foo</loc></url><url><loc>https://test.com/nested/</loc></url><url><loc>https://test.com/nested/foo</loc></url><url><loc>https://test.com/nested/nested/</loc></url><url><loc>https://test.com/nested/nested/bar</loc></url></urlset>`
+
+		assert.Equal(t, expected, smap)
+	})
+
+	t.Run("creates expected sitemap from pages including when base path is specified", func(t *testing.T) {
+		smap := sitemap.Build("test.com", "/test", testPages)
+
+		expected := `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>https://test.com/test/</loc></url><url><loc>https://test.com/test/foo</loc></url><url><loc>https://test.com/test/nested/</loc></url><url><loc>https://test.com/test/nested/foo</loc></url><url><loc>https://test.com/test/nested/nested/</loc></url><url><loc>https://test.com/test/nested/nested/bar</loc></url></urlset>`
+
+		assert.Equal(t, expected, smap)
+	})
+}

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -1,0 +1,76 @@
+package validate
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"strings"
+)
+
+var ErrDomainEmpty = errors.New("domain cannot be empty")
+var ErrDomainInvalid = errors.New("domain is invalid, check it does not include spaces or any illegal characters")
+
+func IsValidDomain(domain string) error {
+	if domain == "" {
+		return ErrDomainEmpty
+	}
+
+	parsedUrl, err := url.Parse(domain)
+	if err != nil || parsedUrl.String() != domain {
+		return ErrDomainInvalid
+	}
+
+	return nil
+}
+
+var ErrPathMustStartWithSlash = errors.New("path must start with '/'")
+var ErrPathContainsInvalidCharacters = errors.New("path contains invalid characters")
+var ErrPathContainsDirTraversal = errors.New("path contains illegal '..' for directory traversal")
+var ErrPathMustIncludeFileExt = errors.New("path must end with a file extension e.g. '.html'")
+
+func IsValidFilePath(filePath string) error {
+	if !strings.HasPrefix(filePath, "/") {
+		return ErrPathMustStartWithSlash
+	}
+
+	parsedURL, err := url.Parse(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to parse path: %v", err)
+	}
+
+	if parsedURL.String() != filePath {
+		return ErrPathContainsInvalidCharacters
+	}
+
+	if strings.Contains(parsedURL.Path, "..") {
+		return ErrPathContainsDirTraversal
+	}
+
+	ext := filepath.Ext(parsedURL.Path)
+	if ext == "" {
+		return ErrPathMustIncludeFileExt
+	}
+
+	return nil
+}
+
+var ErrBasePathInvalid = errors.New("base path is invalid, check it does not include spaces or any illegal characters")
+var ErrBasePathTrailingSlash = errors.New("base path should not have a trailing slash '/'")
+
+func IsValidBasePath(basePath string) error {
+	if !strings.HasPrefix(basePath, "/") {
+		return ErrPathMustStartWithSlash
+	}
+
+	parsedUrl, err := url.Parse(basePath)
+	if err != nil || parsedUrl.String() != basePath {
+		return ErrBasePathInvalid
+	}
+
+	if strings.HasSuffix(basePath, "/") {
+		return ErrBasePathTrailingSlash
+	}
+
+	return nil
+}

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -1,0 +1,106 @@
+package validate_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/man-on-box/litepage/internal/validate"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsValidDomain(t *testing.T) {
+	invalidDomains := []struct {
+		domain        string
+		expectedError error
+	}{
+		{domain: "", expectedError: validate.ErrDomainEmpty},
+		{domain: "domain with spaces", expectedError: validate.ErrDomainInvalid},
+		{domain: "invalid%", expectedError: validate.ErrDomainInvalid},
+	}
+
+	for _, tt := range invalidDomains {
+		t.Run(fmt.Sprintf("expect error for domain '%s'", tt.domain), func(t *testing.T) {
+			err := validate.IsValidDomain(tt.domain)
+			assert.Error(t, err)
+			assert.ErrorIs(t, err, tt.expectedError)
+		})
+	}
+
+	t.Run("returns nil for valid domain", func(t *testing.T) {
+		err := validate.IsValidDomain("hello.com")
+		assert.NoError(t, err)
+	})
+}
+
+func TestIsValidFilePath(t *testing.T) {
+	invalidPaths := []struct {
+		path          string
+		expectedError error
+	}{
+		{path: "", expectedError: validate.ErrPathMustStartWithSlash},
+		{path: "index.html", expectedError: validate.ErrPathMustStartWithSlash},
+		{path: "/../index.html", expectedError: validate.ErrPathContainsDirTraversal},
+		{path: "/index", expectedError: validate.ErrPathMustIncludeFileExt},
+		{path: "/index file.html", expectedError: validate.ErrPathContainsInvalidCharacters},
+		{path: "/index>file.html", expectedError: validate.ErrPathContainsInvalidCharacters},
+	}
+
+	for _, tt := range invalidPaths {
+		t.Run(fmt.Sprintf("expect error for path '%s'", tt.path), func(t *testing.T) {
+			err := validate.IsValidFilePath(tt.path)
+			assert.Error(t, err)
+			assert.ErrorIs(t, err, tt.expectedError)
+		})
+	}
+
+	validPaths := []string{
+		"/foo.html",
+		"/foo.htm",
+		"/nested/foo.htm",
+		"/nested/foo.txt",
+		"/file-hyphen_underscore.html",
+	}
+
+	for _, path := range validPaths {
+		t.Run(fmt.Sprintf("no error returned for valid domain '%s'", path), func(t *testing.T) {
+			err := validate.IsValidFilePath(path)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestIsValidBasePath(t *testing.T) {
+	invalidPaths := []struct {
+		path          string
+		expectedError error
+	}{
+		{path: "", expectedError: validate.ErrPathMustStartWithSlash},
+		{path: "/invalid path", expectedError: validate.ErrBasePathInvalid},
+		{path: "/invalid%path", expectedError: validate.ErrBasePathInvalid},
+		{path: "/invalid<>path", expectedError: validate.ErrBasePathInvalid},
+		{path: "/", expectedError: validate.ErrBasePathTrailingSlash},
+		{path: "/path-with-trailing-slash/", expectedError: validate.ErrBasePathTrailingSlash},
+	}
+
+	for _, tt := range invalidPaths {
+		t.Run(fmt.Sprintf("expect error for path '%s'", tt.path), func(t *testing.T) {
+			err := validate.IsValidBasePath(tt.path)
+			assert.Error(t, err)
+			assert.ErrorIs(t, err, tt.expectedError)
+		})
+	}
+
+	validPaths := []string{
+		"/test",
+		"/nested/test",
+		"/test-path_",
+	}
+
+	for _, path := range validPaths {
+		t.Run(fmt.Sprintf("no error for valid path '%s'", path), func(t *testing.T) {
+			err := validate.IsValidBasePath(path)
+			assert.NoError(t, err)
+		})
+
+	}
+}

--- a/litepage.go
+++ b/litepage.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 
 	"github.com/man-on-box/litepage/internal/build"
-	"github.com/man-on-box/litepage/internal/common"
+	"github.com/man-on-box/litepage/internal/model"
 	"github.com/man-on-box/litepage/internal/serve"
 )
 
@@ -57,7 +57,7 @@ type litepage struct {
 	publicDir   string
 	basePath    string
 	withSitemap bool
-	pages       *[]common.Page
+	pages       *[]model.Page
 	pathMap     map[string]bool
 }
 
@@ -79,7 +79,7 @@ func New(domain string, options ...Option) (Litepage, error) {
 		publicDir:   "public",
 		withSitemap: true,
 		pathMap:     map[string]bool{},
-		pages:       &[]common.Page{},
+		pages:       &[]model.Page{},
 	}
 
 	for _, opt := range options {
@@ -126,7 +126,7 @@ func (lp *litepage) Page(filePath string, handler func(w io.Writer)) error {
 	// Because there is no native ordered map in Go, I opted to use a slice to preserve
 	// page insertion order, and copy the file path into a map for o(1) lookup time.
 	lp.pathMap[filePath] = true
-	*lp.pages = append(*lp.pages, common.Page{Path: filePath, Handler: handler})
+	*lp.pages = append(*lp.pages, model.Page{Path: filePath, Handler: handler})
 
 	return nil
 }

--- a/litepage.go
+++ b/litepage.go
@@ -65,9 +65,12 @@ type litepage struct {
 // The domain parameter is required and must be a non-empty string representing the site's domain.
 // The options parameter allows for additional configurations to be applied to the Litepage instance.
 func New(domain string, options ...Option) (Litepage, error) {
+	if domain == "" {
+		return nil, fmt.Errorf("site domain is required, please provide a domain like 'catpics.com'")
+	}
 	err := isValidDomain(domain)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("site domain is not valid: %v", err)
 	}
 
 	lp := &litepage{
@@ -162,13 +165,9 @@ func (lp *litepage) BuildOrServe() error {
 }
 
 func isValidDomain(domain string) error {
-	if domain == "" {
-		return fmt.Errorf("site domain is required, please provide a domain like 'catpics.com'")
-	}
-
 	parsedUrl, err := url.Parse(domain)
 	if err != nil || parsedUrl.String() != domain {
-		return fmt.Errorf("site domain '%s' is not valid, check it does not include spaces or any illegal characters", domain)
+		return fmt.Errorf("domain '%s' is not valid, check it does not include spaces or any illegal characters", domain)
 	}
 
 	return nil

--- a/litepage.go
+++ b/litepage.go
@@ -148,6 +148,7 @@ func (lp *litepage) Build() error {
 		PublicDir:   lp.publicDir,
 		Pages:       lp.pages,
 		SiteDomain:  lp.siteDomain,
+		BasePath:    lp.basePath,
 		WithSitemap: lp.withSitemap,
 	}
 	builder := build.New(bc)

--- a/litepage.go
+++ b/litepage.go
@@ -122,12 +122,24 @@ func (lp *litepage) Page(filePath string, handler func(w io.Writer)) error {
 }
 
 func (lp *litepage) Serve(port string) error {
-	server := serve.New(lp.publicDir, lp.pages, lp.siteDomain, lp.withSitemap)
+	sc := serve.Config{
+		PublicDir:   lp.publicDir,
+		Pages:       lp.pages,
+		SiteDomain:  lp.siteDomain,
+		WithSitemap: lp.withSitemap,
+	}
+	server := serve.New(sc)
 	return server.Serve(port)
 }
 
 func (lp *litepage) Build() error {
-	builder := build.New(lp.distDir, lp.publicDir, lp.pages, lp.siteDomain, lp.withSitemap)
+	bc := build.Config{
+		PublicDir:   lp.publicDir,
+		Pages:       lp.pages,
+		SiteDomain:  lp.siteDomain,
+		WithSitemap: lp.withSitemap,
+	}
+	builder := build.New(bc)
 	return builder.Build()
 }
 

--- a/litepage.go
+++ b/litepage.go
@@ -136,6 +136,7 @@ func (lp *litepage) Serve(port string) error {
 		PublicDir:   lp.publicDir,
 		Pages:       lp.pages,
 		SiteDomain:  lp.siteDomain,
+		BasePath:    lp.basePath,
 		WithSitemap: lp.withSitemap,
 	}
 	server := serve.New(sc)

--- a/litepage_test.go
+++ b/litepage_test.go
@@ -17,12 +17,12 @@ func TestCreateNewLitepage(t *testing.T) {
 
 	t.Run("Errors if domain contains spaces", func(t *testing.T) {
 		_, err := litepage.New("invalid domain")
-		assert.ErrorContains(t, err, "site domain 'invalid domain' is not valid")
+		assert.ErrorContains(t, err, "site domain is not valid")
 	})
 
 	t.Run("Errors if domain contains illegal characters", func(t *testing.T) {
 		_, err := litepage.New("invaliddomain%=?")
-		assert.ErrorContains(t, err, "site domain 'invaliddomain%=?' is not valid")
+		assert.ErrorContains(t, err, "site domain is not valid")
 	})
 
 	t.Run("Returns no error when correct domain is supplied", func(t *testing.T) {

--- a/litepage_test.go
+++ b/litepage_test.go
@@ -1,7 +1,6 @@
 package litepage_test
 
 import (
-	"fmt"
 	"io"
 	"testing"
 
@@ -12,16 +11,13 @@ import (
 func TestCreateNewLitepage(t *testing.T) {
 	t.Run("Errors if domain is not specified", func(t *testing.T) {
 		_, err := litepage.New("")
+		assert.Error(t, err)
 		assert.ErrorContains(t, err, "site domain is required")
 	})
 
-	t.Run("Errors if domain contains spaces", func(t *testing.T) {
+	t.Run("Errors if domain is invalid", func(t *testing.T) {
 		_, err := litepage.New("invalid domain")
-		assert.ErrorContains(t, err, "site domain is not valid")
-	})
-
-	t.Run("Errors if domain contains illegal characters", func(t *testing.T) {
-		_, err := litepage.New("invaliddomain%=?")
+		assert.Error(t, err)
 		assert.ErrorContains(t, err, "site domain is not valid")
 	})
 
@@ -29,80 +25,32 @@ func TestCreateNewLitepage(t *testing.T) {
 		_, err := litepage.New("nice-domain.com")
 		assert.NoError(t, err)
 	})
+
+	t.Run("Returns error if base path is supplied and not valid", func(t *testing.T) {
+		_, err := litepage.New("nice-domain.com", litepage.WithBasePath("/"))
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "base path is not valid")
+
+	})
 }
 
 func TestAddNewPage(t *testing.T) {
-	tests := []struct {
-		filePath      string
-		expectError   bool
-		errorContains string
-	}{
-		{
-			filePath:    "/foo.html",
-			expectError: false,
-		},
-		{
-			filePath:    "/foo.htm",
-			expectError: false,
-		},
-		{
-			filePath:    "/nested/foo.htm",
-			expectError: false,
-		},
-		{
-			filePath:    "/nested/foo.txt",
-			expectError: false,
-		}, {
-			filePath:    "/file-hyphen_underscore.html",
-			expectError: false,
-		},
-		{
-			filePath:      "",
-			expectError:   true,
-			errorContains: "must start with '/'",
-		},
-		{
-			filePath:      "index.html",
-			expectError:   true,
-			errorContains: "must start with '/'",
-		},
-		{
-			filePath:      "/../index.html",
-			expectError:   true,
-			errorContains: "contains illegal '..'",
-		},
-		{
-			filePath:      "/index",
-			expectError:   true,
-			errorContains: "must end with a file extension",
-		},
-		{
-			filePath:      "/index file.html",
-			expectError:   true,
-			errorContains: "contains invalid character",
-		}, {
-			filePath:      "/index<.html",
-			expectError:   true,
-			errorContains: "contains invalid character",
-		},
-	}
+	t.Run("errors when adding an invalid path", func(t *testing.T) {
+		lp, err := litepage.New("test.com")
+		assert.NoError(t, err)
 
-	for _, tt := range tests {
-		t.Run(fmt.Sprintf("Expect error '%t' for path '%s'", tt.expectError, tt.filePath), func(t *testing.T) {
-			lp, err := litepage.New("test.com")
-			assert.NoError(t, err)
+		err = lp.Page("/invalid path", func(w io.Writer) {})
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "error when validating file path")
+	})
 
-			err = lp.Page(tt.filePath, func(w io.Writer) {})
+	t.Run("returns no error when adding valid page", func(t *testing.T) {
+		lp, err := litepage.New("test.com")
+		assert.NoError(t, err)
 
-			if tt.expectError {
-				assert.Error(t, err)
-				assert.ErrorContains(t, err, tt.errorContains)
-			} else {
-				assert.NoError(t, err)
-			}
-
-		})
-	}
+		err = lp.Page("/foo.html", func(w io.Writer) {})
+		assert.NoError(t, err)
+	})
 
 	t.Run("Errors when trying to add the same path twice", func(t *testing.T) {
 		lp, err := litepage.New("test.com")


### PR DESCRIPTION
# Summary

Adding the ability to add a base path. This is useful for when you are deploying a site that does not exist on the root domain. 

## Changes
- Can now init with the option `WithBasePath`
- Refactored some internals for better organisation and testing
- Added a custom 404 page to ascetics and hints when base path is supplied
- the example site is now configured with a base path (potentially could host this via Github pages)